### PR TITLE
Info Button Bug Fix

### DIFF
--- a/info.py
+++ b/info.py
@@ -29,43 +29,44 @@ class BVTK_Node_Info(Node, BVTK_Node):
         else:
             vtkobj = resolve_algorithm_output(vtkobj)
             if not vtkobj:
-                return
+                layout.label(text='Failed to resolve algorithm ouput (try updating)')
+            else:
 
-            layout.label(text='Type: ' + vtkobj.__class__.__name__)
+                layout.label(text='Type: ' + vtkobj.__class__.__name__)
 
-            layout.label(text='Points: ' + str(vtkobj.GetNumberOfPoints()))
-            if hasattr(vtkobj, 'GetNumberOfCells'):
-                layout.label(text='Cells: ' + str(vtkobj.GetNumberOfCells()))
-            if hasattr(vtkobj, 'GetBounds'):
-                layout.label(text='X range: ' + fs.format(vtkobj.GetBounds()[0]) + \
-                             ' - ' + fs.format(vtkobj.GetBounds()[1]))
-                layout.label(text='Y range: ' + fs.format(vtkobj.GetBounds()[2]) + \
-                             ' - ' + fs.format(vtkobj.GetBounds()[3]))
-                layout.label(text='Z range: ' + fs.format(vtkobj.GetBounds()[4]) + \
-                             ' - ' + fs.format(vtkobj.GetBounds()[5]))
-            data = {}
-            if hasattr(vtkobj, 'GetPointData'):
-                data['Point data '] = vtkobj.GetPointData()
-            if hasattr(vtkobj, 'GetCellData'):
-                data['Cell data '] = vtkobj.GetCellData()
-            if hasattr(vtkobj, 'GetFieldData'):
-                data['Field data '] = vtkobj.GetFieldData()
-            for k in data:
-                d = data[k]
-                for i in range(d.GetNumberOfArrays()):
-                    arr = d.GetArray(i)
-                    data_type_name = arr.GetDataTypeAsString()
-                    n_comps = arr.GetNumberOfComponents()
-                    name = arr.GetName()
-                    range_text = ''
-                    for n in range(n_comps):
-                        r = arr.GetRange(n)
-                        range_text += '[' + fs.format(r[0]) +', ' + fs.format(r[1]) + ']  '
-                    row = layout.row()
-                    row.label(text = k + '[' + str(i) + '] (' \
-                              + str(data_type_name) + str(n_comps) \
-                              + '): \'' + name + '\': ' \
-                              + range_text)
+                layout.label(text='Points: ' + str(vtkobj.GetNumberOfPoints()))
+                if hasattr(vtkobj, 'GetNumberOfCells'):
+                    layout.label(text='Cells: ' + str(vtkobj.GetNumberOfCells()))
+                if hasattr(vtkobj, 'GetBounds'):
+                    layout.label(text='X range: ' + fs.format(vtkobj.GetBounds()[0]) + \
+                                ' - ' + fs.format(vtkobj.GetBounds()[1]))
+                    layout.label(text='Y range: ' + fs.format(vtkobj.GetBounds()[2]) + \
+                                ' - ' + fs.format(vtkobj.GetBounds()[3]))
+                    layout.label(text='Z range: ' + fs.format(vtkobj.GetBounds()[4]) + \
+                                ' - ' + fs.format(vtkobj.GetBounds()[5]))
+                data = {}
+                if hasattr(vtkobj, 'GetPointData'):
+                    data['Point data '] = vtkobj.GetPointData()
+                if hasattr(vtkobj, 'GetCellData'):
+                    data['Cell data '] = vtkobj.GetCellData()
+                if hasattr(vtkobj, 'GetFieldData'):
+                    data['Field data '] = vtkobj.GetFieldData()
+                for k in data:
+                    d = data[k]
+                    for i in range(d.GetNumberOfArrays()):
+                        arr = d.GetArray(i)
+                        data_type_name = arr.GetDataTypeAsString()
+                        n_comps = arr.GetNumberOfComponents()
+                        name = arr.GetName()
+                        range_text = ''
+                        for n in range(n_comps):
+                            r = arr.GetRange(n)
+                            range_text += '[' + fs.format(r[0]) +', ' + fs.format(r[1]) + ']  '
+                        row = layout.row()
+                        row.label(text = k + '[' + str(i) + '] (' \
+                                + str(data_type_name) + str(n_comps) \
+                                + '): \'' + name + '\': ' \
+                                + range_text)
 
         layout.separator()
         row = layout.row()


### PR DESCRIPTION
- Keeps the update button even if the output of the resolve_algo is None
- Done to allow progressive info updates through the node tree.

Description:
When using info boxes to debug a node tree, if one used multiple info boxes the deep info boxes would become unusable if one closer to the root was updated. For example:
![image](https://user-images.githubusercontent.com/5533524/109408173-d9030680-7954-11eb-85fe-3afbf7108c9a.png)
The second info box become unusable because I updated the one closest to the reader first. I *believe* this was due to the down stream nodes not being executed (never added in the BVTK_FunctionsQueue) so it returns none when asked to resolve_algorithm_output.

Now the info box just warns that the output failed and to try updating again similar to if input is not a vtkobj.
![image](https://user-images.githubusercontent.com/5533524/109408274-d228c380-7955-11eb-8623-41afd760849e.png)
which allows the second info to be updated later, executing the next part of the tree.

