### PR TITLE
VTK Information Pipeline Bug fix

### DIFF
--- a/core.py
+++ b/core.py
@@ -214,7 +214,6 @@ def run_custom_code(func):
                 cmd = 'vtkobj.' + x
                 l.debug("%s run %r" % (vtkobj.__vtkname__, cmd))
                 exec(cmd, globals(), locals())
-            exec('vtkobj.Update()', globals(), locals())
         return value
     return run_custom_code_wrapper
 


### PR DESCRIPTION
- Removed updated call from run_custom_code wrapper
- VTK models should be only updated with updateobj to ensure props and inputs have been applied.

This should fix many of the errors of the form:
> vtkCompositeDataPipeline (0x7f0,5d2,f02,f40): Algorithm vtkPassArrays(0x7f0,5d3,c37,420) returned failure for request: vtkInformation (0x7f0,5d3,58d,980)
>      Debug: Off
>      Modified Time: 28215
>      Reference Count: 1
>      Registered Events: (none)
>      Request: REQUEST_DATA_OBJECT
>      ALGORITHM_AFTER_FORWARD: 1
>      FORWARD_DIRECTION: 0 

See Issue #34 for details.