### PR TITLE
BVTK Cache Refactoring

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -73,6 +73,7 @@ if need_reloading:
 
     importlib.reload(update)
     importlib.reload(core)
+    importlib.reload(cache)
     importlib.reload(b_properties)
     importlib.reload(showhide_properties)
     importlib.reload(tree)
@@ -112,6 +113,7 @@ else:
     from   nodeitems_utils import NodeItem
 
     from . import core
+    from . import cache
     from . import b_properties
     from . import showhide_properties
     from . import b_inspect
@@ -144,7 +146,7 @@ l.info("VTK base path: " + vtk.__file__)
 @persistent
 def on_file_loaded(scene):
     '''Initialize cache after a blender file open'''
-    core.init_cache()
+    cache.BVTKCache.init()
 
 
 @persistent

--- a/b_inspect.py
+++ b/b_inspect.py
@@ -1,6 +1,7 @@
 import bpy
 import bpy.utils.previews
 from .core import *
+from .cache import BVTKCache
 
 # -----------------------------------------------------------------------------
 # Dubug panel and node documentation panel (information about
@@ -147,7 +148,7 @@ class BVTK_OT_UpdateObj(bpy.types.Operator):
     prop: bpy.props.StringProperty()
 
     def execute(self, context):
-        check_cache()
+        BVTKCache.check_cache()
         active_node = context.active_node
         vtkobj = active_node.get_vtkobj()
         log_check()

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,121 @@
+import logging
+import bpy
+import vtk
+
+l = logging.getLogger(__name__)
+
+
+nodeMaxId:int = 1   # Maximum node id number. 0 means invalid
+nodesIdMap:dict = {}  # node_id -> node
+vtkCache:dict = {}  # node_id -> vtkobj
+
+class BVTKCache:
+
+    @classmethod
+    def init(cls):
+        """ Initialzed cache/node ids
+        """
+        global nodeMaxId, nodesIdMap, vtkCache
+
+        nodeMaxId = 1
+        nodesIdMap = {}
+        vtkCache = {}
+        cls.check_cache()
+    
+    @classmethod
+    def check_cache(cls):
+        '''Rebuild Node Cache. Called by all operators. Cache is out of sync
+        if an operator is called and at the same time NodesMaxId=1.
+        This happens after reloading addons. Cache is rebuilt, and the
+        operator must be interrupted, but the next operator call will work
+        OK.
+        '''
+        # After F8 or FileOpen VTKCache is empty and NodesMaxId == 1
+        # any previous node_id must be invalidated
+        if nodeMaxId == 1:
+            for nt in bpy.data.node_groups:
+                if nt.bl_idname == 'BVTK_NodeTreeType':
+                    for n in nt.nodes:
+                        n.node_id = 0
+
+        # For each node check if it has a node_id
+        # and if it has a vtk_obj associated
+        for nt in bpy.data.node_groups:
+            if nt.bl_idname == 'BVTK_NodeTreeType':
+                for n in nt.nodes:
+                    if cls.get_vtkobj(n) == None or n.node_id == 0:
+                        cls.map_node(n)
+                        cls.init_vtkobj(n)
+
+    @classmethod
+    def init_vtkobj(cls, node):
+        '''Instantiate the nodes vtkobj and store it in VTKCache.
+        '''
+        global vtkCache
+        
+        # create the node vtk_obj if needed
+        if node.bl_label.startswith('vtk'):
+            vtk_class = getattr(vtk, node.bl_label, None)
+            if vtk_class is None:
+                l.error("bad classname " + node.bl_label)
+                return
+            vtkCache[node.node_id] = vtk_class()
+            l.debug("Created VTK object of type " + node.bl_label + ", id " + str(node.node_id))
+        else:
+            vtkCache[node.node_id] = None
+
+    @classmethod
+    def map_node(cls, node, force=False):
+        '''Adds node to node map and intializes its vtkcache object.
+        Called when building the cache
+        '''
+        global nodeMaxId, nodesIdMap, vtkCache
+
+        if node.node_id == 0 or force:
+            node.node_id = nodeMaxId
+            l.debug("Initialize new node: %s, id %d" % (node.name, node.node_id))
+            vtkCache[node.node_id] = None
+            nodesIdMap[node.node_id] = node
+            nodeMaxId += 1 # Index node id for next created node
+
+    @classmethod
+    def unmap_node(cls, node):
+        '''Remove node from Node Cache. To be called from node.free().
+        Remove node from NodesMap and its vtkobj from VTKCache
+        '''
+        global nodesIdMap, vtkCache
+
+        if node.node_id in NodesMap:
+            del nodesIdMap[node.node_id]
+
+        if node.node_id in vtkCache:
+            obj = vtkCache[node.node_id]
+            # if obj: 
+            #     obj.UnRegister(obj)  # vtkObjects have no Delete in Python -- maybe is not needed
+            del vtkCache[node.node_id]
+        l.debug("deleted " + node.bl_label + " " + str(node.node_id))
+
+    @classmethod
+    def get_node(cls, node_id):
+        '''Get node corresponding to node_id. Called by BVTK_OT_NodeWrite'''
+        global nodesIdMap
+
+        if node_id in nodesIdMap:
+            return nodesIdMap[node_id]
+        else:
+            l.error("not found node_id " + node_id)
+            return None
+
+    @classmethod
+    def get_vtkobj(cls, node):
+        '''Get the VTK object associated to a node'''
+        global vtkCache
+        
+        if node is None:
+            l.error("bad node " + str(node))
+            return None
+
+        if not node.node_id in vtkCache:
+            return vtkCache
+
+        return vtkCache[node.node_id]

--- a/cache.py
+++ b/cache.py
@@ -10,11 +10,12 @@ nodesIdMap:dict = {}  # node_id -> node
 vtkCache:dict = {}  # node_id -> vtkobj
 
 class BVTKCache:
-
+    '''Class for accessing vtkCache and nodemap
+    '''
     @classmethod
     def init(cls):
-        """ Initialzed cache/node ids
-        """
+        ''' Initialzed cache/node ids
+        '''
         global nodeMaxId, nodesIdMap, vtkCache
 
         nodeMaxId = 1
@@ -43,8 +44,9 @@ class BVTKCache:
         for nt in bpy.data.node_groups:
             if nt.bl_idname == 'BVTK_NodeTreeType':
                 for n in nt.nodes:
-                    if cls.get_vtkobj(n) == None or n.node_id == 0:
+                    if n.node_id == 0:
                         cls.map_node(n)
+                    if cls.get_vtkobj(n) == None:
                         cls.init_vtkobj(n)
 
     @classmethod
@@ -66,7 +68,7 @@ class BVTKCache:
 
     @classmethod
     def map_node(cls, node, force=False):
-        '''Adds node to node map and intializes its vtkcache object.
+        '''Assigned new node its unique ID and adds node to node map.
         Called when building the cache
         '''
         global nodeMaxId, nodesIdMap, vtkCache
@@ -80,12 +82,12 @@ class BVTKCache:
 
     @classmethod
     def unmap_node(cls, node):
-        '''Remove node from Node Cache. To be called from node.free().
+        '''Remove node from cache. To be called from node.free().
         Remove node from NodesMap and its vtkobj from VTKCache
         '''
         global nodesIdMap, vtkCache
 
-        if node.node_id in NodesMap:
+        if node.node_id in nodesIdMap:
             del nodesIdMap[node.node_id]
 
         if node.node_id in vtkCache:
@@ -116,6 +118,6 @@ class BVTKCache:
             return None
 
         if not node.node_id in vtkCache:
-            return vtkCache
+            return None
 
         return vtkCache[node.node_id]

--- a/colormap.py
+++ b/colormap.py
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------------------------
 
 from .core import *
+from .cache import BVTKCache
 
 def get_default_texture(name):
     '''Create and return a new color ramp BLEND type brush texture'''
@@ -118,7 +119,7 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
         if self.default_texture:
             if self.default_texture in bpy.data.textures:
                 bpy.data.texures.remove(bpy.data.textures[self.default_texture])
-        node_deleted(self)
+        BVTKCache.unmap_node(self)
 
     def draw_buttons(self, context, layout):
         in_node, vtkobj = self.get_input_node('input')
@@ -192,7 +193,7 @@ class BVTK_Node_ColorRamp(Node, BVTK_Node):
     def free(self):
         if self.my_texture in bpy.data.textures:
             bpy.data.textures.remove(bpy.data.textures[self.my_texture])
-        node_deleted(self)
+        BVTKCache.unmap_node(self)
 
     def draw_buttons(self, context, layout):
         if self.my_texture in bpy.data.textures.keys():

--- a/converters.py
+++ b/converters.py
@@ -1,6 +1,7 @@
 from .update import *
 from .core import l # Import logging
 from .core import *
+from .cache import BVTKCache
 import bmesh
 
 try:
@@ -1329,7 +1330,7 @@ class BVTK_OT_AutoUpdateScan(bpy.types.Operator):
                 props, conn = differences(actual_map, self.last_map)
                 if props or conn:
                     self.last_map = actual_map
-                    check_cache()
+                    BVTKCache.check_cache()
                     try:
                         no_queue_update(self.node, self.node.update_cb)
                     except Exception as e:
@@ -1683,7 +1684,7 @@ class BVTK_OT_NodeUpdate(bpy.types.Operator):
     use_queue: bpy.props.BoolProperty(default = True)
 
     def execute(self, context):
-        check_cache()
+        BVTKCache.check_cache()
         node = eval(self.node_path)
         if node:
             if self.use_queue:

--- a/core.py
+++ b/core.py
@@ -116,7 +116,9 @@ class BVTK_Node:
         return ntree.bl_idname == 'BVTK_NodeTreeType'
 
     def free(self):
-        BVTKCache.node_deleted(self)
+        '''Clean up node on removal
+        '''
+        BVTKCache.unmap_node(self)
 
     def get_output(self, socketname):
         '''Get output object. Return an object depending on socket
@@ -171,8 +173,12 @@ class BVTK_Node:
         return (0,0)
 
     def get_vtkobj(self):
-        '''Shortcut to get vtkobj'''
+        '''Accessor of nodes vtkobj from cache'''
         return BVTKCache.get_vtkobj(self)
+
+    def reset_vtkobj(self):
+        '''Resets node's vtkobj'''
+        return BVTKCache.init_vtkobj(self)
 
     @show_custom_code
     def draw_buttons(self, context, layout):

--- a/core.py
+++ b/core.py
@@ -24,130 +24,7 @@ import functools # for decorators
 from . import b_properties # Boolean properties
 b_path = b_properties.__file__ # Boolean properties config file path
 from .update import *
-
-# -----------------------------------------------------------------------------
-# Node Cache and related functions
-# -----------------------------------------------------------------------------
-NodesMaxId = 1   # Maximum node id number. 0 means invalid
-NodesMap   = {}  # node_id -> node
-VTKCache   = {}  # node_id -> vtkobj
-
-
-def node_created(node):
-    '''Add node to Node Cache. Called from node.init() and from
-    check_cache. Give the node a unique node_id, then add it in
-    NodesMap, and finally instantiate it's vtkobj and store it in
-    VTKCache.
-    '''
-    global NodesMaxId, NodesMap, VTKCache  
-
-    # Ensure each node has a node_id
-    if node.node_id == 0:
-        node.node_id = NodesMaxId
-        l.debug("Initialize new node: %s, id %d" % (node.name, node.node_id))
-        NodesMaxId += 1
-        NodesMap[node.node_id] = node
-        VTKCache[node.node_id] = None
-
-    # create the node vtk_obj if needed
-    if node.bl_label.startswith('vtk'):
-        vtk_class = getattr(vtk, node.bl_label, None)
-        if vtk_class is None:
-            l.error("bad classname " + node.bl_label)
-            return
-        VTKCache[node.node_id] = vtk_class() # make an instance of node.vtk_class
-
-        # setting properties tips
-        # if hasattr(node,'m_properties'):
-        #     for m_property in node.m_properties():
-        #         prop=getattr(getattr(bpy.types, node.bl_idname), m_property)
-        #         prop_doc=getattr(node.get_vtkobj(), m_property.replace('m_','Set'), 'Doc not found')
-        #
-        #         if prop_doc!='Doc not found':
-        #             prop_doc=prop_doc.__doc__
-        #
-        #         s=''
-        #         for a in prop[1].keys():
-        #             if a!='attr' and a!='description':
-        #                 s+=a+'='+repr(prop[1][a])+', '
-        #
-        #         exec('bpy.types.'+node.bl_idname+'.'+m_property+'=bpy.props.'+prop[0].__name__+'('+s+' description='+repr(prop_doc)+')')
-    
-        l.debug("Created VTK object of type " + node.bl_label + ", id " + str(node.node_id))
-
-
-def node_deleted(node):
-    '''Remove node from Node Cache. To be called from node.free().
-    Remove node from NodesMap and its vtkobj from VTKCache
-    '''
-    global NodesMap, VTKCache  
-    if node.node_id in NodesMap:
-        del NodesMap[node.node_id]
-
-    if node.node_id in VTKCache:
-        obj = VTKCache[node.node_id]
-        # if obj: 
-        #     obj.UnRegister(obj)  # vtkObjects have no Delete in Python -- maybe is not needed
-        del VTKCache[node.node_id]
-    l.debug("deleted " + node.bl_label + " " + str(node.node_id))
-
-
-def get_node(node_id):
-    '''Get node corresponding to node_id.'''
-    node = NodesMap.get(node_id)
-    if node is None:
-        l.error("not found node_id " + node_id)
-    return node
-
-
-def get_vtkobj(node):
-    '''Get the VTK object associated to a node'''
-    if node is None:
-        l.error("bad node " + str(node))
-        return None
-
-    if not node.node_id in VTKCache:
-        # l.debug("node %s (id %d) is not in cache" % (node.name, node.node_id))
-        return None
-
-    return VTKCache[node.node_id]
-
-
-def init_cache():
-    '''Initialize Node Cache'''
-    global NodesMaxId, NodesMap, VTKCache  
-    l.debug("Initializing")
-    NodesMaxId = 1
-    NodesMap   = {}
-    VTKCache   = {}
-    check_cache()
-    print_nodes()
-
-
-def check_cache():
-    '''Rebuild Node Cache. Called by all operators. Cache is out of sync
-    if an operator is called and at the same time NodesMaxId=1.
-    This happens after reloading addons. Cache is rebuilt, and the
-    operator must be interrupted, but the next operator call will work
-    OK.
-    '''
-    global NodesMaxId
-
-    # After F8 or FileOpen VTKCache is empty and NodesMaxId == 1
-    # any previous node_id must be invalidated
-    if NodesMaxId == 1:
-        for nt in bpy.data.node_groups:
-            if nt.bl_idname == 'BVTK_NodeTreeType':
-                for n in nt.nodes:
-                    n.node_id = 0
-
-    # For each node check if it has a node_id
-    # and if it has a vtk_obj associated
-    for nt in bpy.data.node_groups:
-        if nt.bl_idname == 'BVTK_NodeTreeType':
-            for n in nt.nodes:
-                if get_vtkobj(n) == None or n.node_id == 0:
-                    node_created(n)
+from .cache import BVTKCache
 
 
 # -----------------------------------------------------------------------------
@@ -239,7 +116,7 @@ class BVTK_Node:
         return ntree.bl_idname == 'BVTK_NodeTreeType'
 
     def free(self):
-        node_deleted(self)
+        BVTKCache.node_deleted(self)
 
     def get_output(self, socketname):
         '''Get output object. Return an object depending on socket
@@ -265,7 +142,7 @@ class BVTK_Node:
 
         l.error("bad output link name " + socketname)
         return None
-        
+
     def get_input_nodes(self, name):
         '''Return inputs of a node. Name argument specifies the type of inputs: 
         'self'                 -> input_node.get_vtkobj()
@@ -295,7 +172,7 @@ class BVTK_Node:
 
     def get_vtkobj(self):
         '''Shortcut to get vtkobj'''
-        return get_vtkobj(self)
+        return BVTKCache.get_vtkobj(self)
 
     @show_custom_code
     def draw_buttons(self, context, layout):
@@ -310,7 +187,7 @@ class BVTK_Node:
     def copy(self, node):
         '''Copies setup from another node'''
         self.node_id = 0
-        check_cache()
+        BVTKCache.check_cache()
         if hasattr(self, 'copy_setup'):
             # some nodes need to set properties (such as color ramp elements)
             # after being copied
@@ -369,7 +246,7 @@ class BVTK_Node:
         self.width = 200
         self.use_custom_color = True
         self.color = 0.5,0.5,0.5
-        check_cache()
+        BVTKCache.check_cache()
         input_ports, output_ports, extra_input, extra_output = self.m_connections()
         input_ports.extend(extra_input)
         output_ports.extend(extra_output)
@@ -420,7 +297,7 @@ class BVTK_OT_NodeWrite(bpy.types.Operator):
     id: bpy.props.IntProperty()
 
     def execute(self, context):
-        check_cache()
+        BVTKCache.check_cache()
         node = get_node(self.id)  # TODO: change node_id to node_path?
         if node:
             def cb():


### PR DESCRIPTION
This is a PR for refactoring the code related to the vtkobj cache and node map. Originally the cache was defined in [core.py](https://github.com/tkeskita/BVtkNodes/blob/master/core.py). 

Thoughts on original implementation:
- When working through this code, this made debugging difficult since the methods were just accessed through the file.
- Additionally when other files `from core import *`, they also gain access to the cache objects which is not ideal in my opinion since this allows random classes to modify these files instead of using predefined methods.

Whats new:
- A new cache.py file used for storing python objects that cannot be wrapped in blender's object class (so the vtkcache and nodemap). 
- Created a class BVTKCache with class methods to funnel access to the cache though one central location. 
- The idea is only BVTKCache has access to the global cache variables directly, all others must go through this class which allows for safety checks to be enforced.

E.g. BVTK_Node -> BVTKCache  -> vtkCache

All methods are basically the same, this is just moving code around to get things prepared for a few bug fixes I believe exist. Only a few things were renamed due to me splitting some methods apart.

Did a fair amount of testing on the examples, let me know your thoughts.