### PR TITLE
Node Based Code Editing

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -7,6 +7,7 @@ l = logging.getLogger(__name__)
 
 nodeMaxId:int = 1   # Maximum node id number. 0 means invalid
 nodesIdMap:dict = {}  # node_id -> node
+treeIdMap:dict = {}  # node_id -> node
 vtkCache:dict = {}  # node_id -> vtkobj
 
 class BVTKCache:
@@ -28,6 +29,7 @@ class BVTKCache:
 
         nodeMaxId = 1
         nodesIdMap = {}
+        treeIdMap = {}
         vtkCache = {}
 
     @classmethod
@@ -52,7 +54,7 @@ class BVTKCache:
             if nt.bl_idname == 'BVTK_NodeTreeType':
                 for n in nt.nodes:
                     if n.node_id == 0:
-                        cls.map_node(n)
+                        cls.map_node(n, tree=nt)
                     if cls.get_vtkobj(n) == None:
                         cls.init_vtkobj(n)
 
@@ -74,17 +76,18 @@ class BVTKCache:
             vtkCache[node.node_id] = None
 
     @classmethod
-    def map_node(cls, node, force=False):
+    def map_node(cls, node, tree=None, force=False):
         '''Assigned new node its unique ID and adds node to node map.
         Called when building the cache
         '''
-        global nodeMaxId, nodesIdMap, vtkCache
+        global nodeMaxId, nodesIdMap, treeIdMap, vtkCache
 
         if node.node_id == 0 or force:
             node.node_id = nodeMaxId
             l.debug("Initialize new node: %s, id %d" % (node.name, node.node_id))
             vtkCache[node.node_id] = None
             nodesIdMap[node.node_id] = node
+            treeIdMap[node.node_id] = tree
             nodeMaxId += 1 # Index node id for next created node
 
     @classmethod
@@ -105,12 +108,23 @@ class BVTKCache:
         l.debug("deleted " + node.bl_label + " " + str(node.node_id))
 
     @classmethod
-    def get_node(cls, node_id):
+    def get_node(cls, node_id:int):
         '''Get node corresponding to node_id. Called by BVTK_OT_NodeWrite'''
         global nodesIdMap
 
         if node_id in nodesIdMap:
             return nodesIdMap[node_id]
+        else:
+            l.error("not found node_id " + node_id)
+            return None
+
+    @classmethod
+    def get_tree(cls, node_id:int):
+        '''Get node tree corresponding to node_id. Called in BVTK_OT_Edit_Custom_Code'''
+        global treeIdMap
+
+        if node_id in treeIdMap:
+            return treeIdMap[node_id]
         else:
             l.error("not found node_id " + node_id)
             return None

--- a/cache.py
+++ b/cache.py
@@ -1,9 +1,9 @@
 import logging
 import bpy
 import vtk
+import functools
 
 l = logging.getLogger(__name__)
-
 
 nodeMaxId:int = 1   # Maximum node id number. 0 means invalid
 nodesIdMap:dict = {}  # node_id -> node
@@ -12,17 +12,24 @@ vtkCache:dict = {}  # node_id -> vtkobj
 class BVTKCache:
     '''Class for accessing vtkCache and nodemap
     '''
+
     @classmethod
     def init(cls):
         ''' Initialzed cache/node ids
+        '''
+        cls.reload()
+        cls.check_cache()
+
+    @classmethod
+    def reload(cls):
+        '''Resets the caches to be recreated from scratch
         '''
         global nodeMaxId, nodesIdMap, vtkCache
 
         nodeMaxId = 1
         nodesIdMap = {}
         vtkCache = {}
-        cls.check_cache()
-    
+
     @classmethod
     def check_cache(cls):
         '''Rebuild Node Cache. Called by all operators. Cache is out of sync

--- a/core.py
+++ b/core.py
@@ -74,8 +74,10 @@ def show_custom_code(func):
         if self.expanded:
             col = layout.column(align=True)
             row = col.row()
-            row.operator('node.bvtk_custom_code_edit', text="Edit", icon="TEXT")
-            row.operator('node.bvtk_custom_code_save', text="Save", icon="FILE_TICK")
+            op = row.operator('node.bvtk_custom_code_edit', text="Edit", icon="TEXT")
+            op.node_id = self.node_id # Set node id in operator
+            op = row.operator('node.bvtk_custom_code_save', text="Save", icon="FILE_TICK")
+            op.node_id = self.node_id # Set node id in operator
             if len(self.custom_code) > 0:
                     box = layout.box()
                     col = box.column()

--- a/core.py
+++ b/core.py
@@ -65,14 +65,23 @@ def show_custom_code(func):
         # Call function first
         value = func(self, context, layout)
         # Then show Custom Code
-        if len(self.custom_code) > 0:
-            row = layout.row()
-            row.label(text="Custom Code:")
-            box = layout.box()
-            col = box.column()
-            for text in self.custom_code.splitlines():
-                row = col.row()
-                row.label(text=text)
+        row = layout.row()
+        row.label(text="Custom Code:")
+        row.prop(self, "expanded",
+            icon="TRIA_DOWN" if self.expanded else "TRIA_LEFT",
+            icon_only=True, emboss=False)
+
+        if self.expanded:
+            col = layout.column(align=True)
+            row = col.row()
+            row.operator('node.bvtk_custom_code_edit', text="Edit", icon="TEXT")
+            row.operator('node.bvtk_custom_code_save', text="Save", icon="FILE_TICK")
+            if len(self.custom_code) > 0:
+                    box = layout.box()
+                    col = box.column()
+                    for text in self.custom_code.splitlines():
+                        row = col.row()
+                        row.label(text=text)
         return value
     return show_custom_code_wrapper
 
@@ -110,6 +119,8 @@ class BVTK_Node:
         default="",
         maxlen=0,
     )
+
+    expanded: bpy.props.BoolProperty(name="Show Code", default=False)
 
     @classmethod
     def poll(cls, ntree):
@@ -342,7 +353,6 @@ def check_b_properties():
 add_class(BVTK_NodeTree)
 add_class(BVTK_NodeSocket)
 add_ui_class(BVTK_OT_NodeWrite)
-
 
 # -----------------------------------------------------------------------------
 # VTK Node Category

--- a/showhide_properties.py
+++ b/showhide_properties.py
@@ -1,6 +1,7 @@
 from .core import l # Import logging
 from . import core
 import bpy
+from .cache import BVTKCache
 
 class BVTK_PT_ShowHide_Properties(bpy.types.Panel):
     '''BVTK Show/hide properties panel'''
@@ -47,9 +48,20 @@ class BVTK_OT_Edit_Custom_Code(bpy.types.Operator):
     '''Edit Custom Code text string for Active Node in Text Editor'''
     bl_idname = "node.bvtk_custom_code_edit"
     bl_label = "Edit Custom Code"
+    node_id: bpy.props.IntProperty(default=0) # Used to save node button press is from
 
     def execute(self, context):
-        active_node = context.active_node
+        if self.node_id == 0: # Call from properities panel
+            active_node = context.active_node
+        else: # Call from node
+            # Get node based on node_id tag and make it active
+            BVTKCache.check_cache()
+            active_node = BVTKCache.get_node(self.node_id)
+            active_node.select = True
+            
+            nt = BVTKCache.get_tree(self.node_id)
+            nt.nodes.active = active_node
+
         name = 'BVTK'
         if name not in bpy.data.texts.keys():
             text = bpy.data.texts.new(name)
@@ -75,9 +87,20 @@ class BVTK_OT_Save_Custom_Code(bpy.types.Operator):
     '''Save Custom Code text from Text Editor to Active Node'''
     bl_idname = "node.bvtk_custom_code_save"
     bl_label = "Save Custom Code"
+    node_id: bpy.props.IntProperty(default=0) # Used to save node button press is from
 
     def execute(self, context):
-        active_node = context.active_node
+        if self.node_id == 0: # Call from properities panel
+            active_node = context.active_node
+        else: # Call from node
+            # Get node based on node_id tag and make it active
+            BVTKCache.check_cache()
+            active_node = BVTKCache.get_node(self.node_id)
+            active_node.select = True
+            
+            nt = BVTKCache.get_tree(self.node_id)
+            nt.nodes.active = active_node
+
         name = 'BVTK'
         if name not in bpy.data.texts.keys():
             self.report({'ERROR'}, "No %r text found in text editor!" % name)

--- a/update.py
+++ b/update.py
@@ -52,6 +52,9 @@ def Update(node, cb, x=True):
     inputs_color = 0.84, 0.84, 0.73 # Input color
     execute_color = 0.85, 0.6, 0.2 # Execution color
 
+    # Reset vtkobj before executing update stack
+    node.reset_vtkobj()
+
     vtkobj = node.get_vtkobj()
 
     # Call update for input nodes
@@ -142,7 +145,6 @@ class BVTK_FunctionsQueue:
 
 # Global functions queue
 queue = BVTK_FunctionsQueue()
-
 
 class BVTK_OT_FunctionQueue(bpy.types.Operator):
     '''Operator to call a function in functions queue. 


### PR DESCRIPTION
**New Feature**
Added a new feature where custom code is accessible on each node via an expandable menu. This menu persists for all nodes that can have custom code, but the hidden menu keeps it compact. Allows the user to select which nodes they want to see for code.
![ExpandingCustomCode](https://user-images.githubusercontent.com/5533524/110261394-129fc700-7f7e-11eb-82ee-61cc6167f369.gif)
Additionally, these expandable menus have an edit and save button that allows for quick accessing of custom code even on nodes that are not active. This can also quickly save the same code to multiple nodes. The original side panel works with these buttons just as before, corresponding the current active node. This should allow for very convenient code editing.

This feature required some modifications to the operators in show/hide plus the addition of a nodetree cache map. But the edits are minimal and integrate into the pre-existing structure of the code.
![ExpandingCustomCode2](https://user-images.githubusercontent.com/5533524/110261519-9194ff80-7f7e-11eb-8806-6c1c0e225a60.gif)
Did a bit of testing but since this is a new feature, may have a bug or two.

**Bug fix**:
Updated the [update function](https://github.com/tkeskita/BVtkNodes/blob/master/update.py#L55) to now recreate the vtkobj, this avoid the following bug where old custom code would persist between updates.
The bug:
![CustomCodeBug](https://user-images.githubusercontent.com/5533524/110261147-049d7680-7f7d-11eb-8de9-a375693fdb81.gif)

Let me know any thoughts or concerns.