### PR TITLE
Some improvements to improve the colormap enum prop

### DIFF
--- a/colormap.py
+++ b/colormap.py
@@ -105,17 +105,27 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
             # Color by point data or cell data
             if self.color_by[0] == 'P':
                 d = vtkobj.GetPointData()
-            else:
+            elif self.color_by[0] == 'C':
                 d = vtkobj.GetCellData()
+            else:
+                d = None
             if d:
                 range = d.GetArray(int(self.color_by[1:])).GetRange()
                 self.max = range[1]
                 self.min = range[0]
+            else:
+                self.max = 0
+                self.min = 0
 
     def color_arrays(self, context):
-        '''Generate array items available for coloring'''
+        '''Generate array items available for coloring
+        
+        TODO: Look into resetting the selected item on new color array.
+        Can access the property via self.bl_rna.properties['color_by']
+        '''
         items = []
         vtkobj = self.get_input_node('input')[1]
+        # self.bl_rna.properties['color_by'].get = self.get_enum
         if vtkobj:
             vtkobj = resolve_algorithm_output(vtkobj)
             if hasattr(vtkobj, 'GetCellData'):
@@ -129,8 +139,12 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
                 for i in range(c_data.GetNumberOfArrays()):
                     arr_name = str(c_data.GetArrayName(i))
                     items.append(('C'+str(i), arr_name, c_descr+arr_name+' array', 'FACESEL', len(items)))
-        if not len(items):
-            items.append(('', '', ''))
+            # If there is no data fields
+            if len(items) == 0:
+                items.append(('E', 'No cell or point data', 'error', 'ERROR', 0))
+        else:
+            # Need to populate enum prop even if no vtkobj to avoid blender warning
+            items.append(('E', 'Input has no vtkobj (try updating)', 'error', 'ERROR', 0))
         return items
 
     # Must define these annotations here after function defs
@@ -170,11 +184,12 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
         BVTKCache.unmap_node(self)
 
     def draw_buttons(self, context, layout):
+
         in_node, vtkobj = self.get_input_node('input')
         if not in_node:
             layout.label(text='Connect a node')
         elif not vtkobj:
-            layout.label(text='Input has not vtkobj (try updating)')
+            layout.label(text='Input has no vtkobj (try updating)')
         else:
             vtkobj = resolve_algorithm_output(vtkobj)
             if hasattr(vtkobj, 'GetPointData'):

--- a/colormap.py
+++ b/colormap.py
@@ -180,7 +180,7 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
     def free(self):
         if self.default_texture:
             if self.default_texture in bpy.data.textures:
-                bpy.data.texures.remove(bpy.data.textures[self.default_texture])
+                bpy.data.textures.remove(bpy.data.textures[self.default_texture])
         BVTKCache.unmap_node(self)
 
     def draw_buttons(self, context, layout):

--- a/converters.py
+++ b/converters.py
@@ -70,12 +70,8 @@ def unwrap_and_color_the_mesh(ob, data, name, ramp, bm, generate_material):
     '''Create UV unwrap corresponding to a generated color image to color
     the mesh. Also generates material if needed.
     '''
-    # If the color mapper currently has an error
-    if len(ramp.color_by) == 0 or ramp.color_by[0] == 'E':
-        return
-
     # Set colors and color legend
-    if ramp and ramp.color_by:
+    if ramp and ramp.color_by and not ramp.color_by[0] == 'E':
         texture = ramp.get_texture()
         if ramp.texture_type == 'IMAGE':
             image_width = 1000
@@ -95,7 +91,7 @@ def unwrap_and_color_the_mesh(ob, data, name, ramp, bm, generate_material):
             bm = face_unwrap(bm, data, int(ramp.color_by[1:]), vrange)
 
     # Generate default material if wanted
-    if generate_material and ramp and ramp.color_by:
+    if generate_material and ramp and ramp.color_by and not ramp.color_by[0] == 'E':
         create_material(ob, texture.name)
     elif generate_material:
         create_material(ob, None)

--- a/converters.py
+++ b/converters.py
@@ -70,6 +70,9 @@ def unwrap_and_color_the_mesh(ob, data, name, ramp, bm, generate_material):
     '''Create UV unwrap corresponding to a generated color image to color
     the mesh. Also generates material if needed.
     '''
+    # If the color mapper currently has an error
+    if len(ramp.color_by) == 0 or ramp.color_by[0] == 'E':
+        return
 
     # Set colors and color legend
     if ramp and ramp.color_by:
@@ -88,7 +91,7 @@ def unwrap_and_color_the_mesh(ob, data, name, ramp, bm, generate_material):
         bm.faces.index_update()
         if ramp.color_by[0] == 'P':
             bm = point_unwrap(bm, data, int(ramp.color_by[1:]), vrange)
-        else:
+        elif ramp.color_by[0] == 'C':
             bm = face_unwrap(bm, data, int(ramp.color_by[1:]), vrange)
 
     # Generate default material if wanted

--- a/info.py
+++ b/info.py
@@ -27,7 +27,7 @@ class BVTK_Node_Info(Node, BVTK_Node):
         if not in_node:
             layout.label(text='Connect a node')
         elif not vtkobj:
-            layout.label(text='Input has not vtkobj (try updating)')
+            layout.label(text='Input has no vtkobj (try updating)')
         else:
             vtkobj = resolve_algorithm_output(vtkobj)
             if not vtkobj:


### PR DESCRIPTION
I wanted to try to get rid of the:
` pyrna_enum_to_py: current value '0' matches no enum in 'BVTK_Node_ColorMapperType', 'Color Mapper', 'color_by' `
warning that blender would spit out frequently with this node. This appears to occur because enum_props have an internal value for tracking the current selected item. When this value is not contained in the enum list, you get this warning.

The current fix is to make sure enum_prop gets populated with at least one item. Avoids the warning on initialization.

Also added some better error checking so the converters do not try to generate a material when theres an issue with the input field field of the colormapper... see example:
![ColormapFix5](https://user-images.githubusercontent.com/5533524/111891821-2579b900-89cc-11eb-8da7-687478f72794.gif)

This is a partial fix, I am not sure if a complete fix is possible with the restricted control of the blender API.  We need to control the selection of the enum prop through python dynamically while still allowing user control. This would allow the error to be solved completely and maybe fix the `setattr failed for color_by` when importing a BVTK Tree JSON. 