### PR TITLE
Append/Caching Bug

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -9,6 +9,7 @@ nodeMaxId:int = 1   # Maximum node id number. 0 means invalid
 nodesIdMap:dict = {}  # node_id -> node
 treeIdMap:dict = {}  # node_id -> node
 vtkCache:dict = {}  # node_id -> vtkobj
+last_update_id:dict = {} # node_id -> last update ID
 
 persistent_storage = {"nodes": {}}
 
@@ -38,12 +39,13 @@ class BVTKCache:
     def reload(cls):
         '''Resets the caches to be recreated from scratch
         '''
-        global nodeMaxId, nodesIdMap, vtkCache
+        global nodeMaxId, nodesIdMap, vtkCache, last_update_id
 
         nodeMaxId = 1
         nodesIdMap = {}
         treeIdMap = {}
         vtkCache = {}
+        last_update_id = {}
 
     @classmethod
     def check_cache(cls):
@@ -70,6 +72,17 @@ class BVTKCache:
                         cls.map_node(n, tree=nt)
                     if cls.get_vtkobj(n) == None:
                         cls.init_vtkobj(n)
+
+    @classmethod
+    def update_necessary(cls, node, update_id):
+        global last_update_id
+        node_id = node.node_id
+        return (not node_id in last_update_id or update_id != last_update_id[node_id])
+
+    @classmethod
+    def update_id(cls, node, update_iter):
+        global last_update_id
+        last_update_id[node.node_id] = update_iter
 
     @classmethod
     def init_vtkobj(cls, node):

--- a/converters.py
+++ b/converters.py
@@ -1,5 +1,6 @@
 from .update import *
 from .core import l # Import logging
+from .core import update_id
 from .core import *
 from .cache import BVTKCache
 import bmesh
@@ -1683,12 +1684,14 @@ class BVTK_OT_NodeUpdate(bpy.types.Operator):
     use_queue: bpy.props.BoolProperty(default = True)
 
     def execute(self, context):
+        global update_id
+        update_id += 1
         BVTKCache.check_cache()
         node = eval(self.node_path)
         if node:
             if self.use_queue:
                 l.debug('Updating with queue from node: '+ node.name)
-                Update(node, node.update_cb)
+                Update(node, node.update_cb, update_id)
             else:
                 l.debug('Updating without queue from node: '+ node.name)
                 no_queue_update(node, node.update_cb)

--- a/core.py
+++ b/core.py
@@ -197,9 +197,12 @@ class BVTK_Node:
         '''Accessor of nodes vtkobj from cache'''
         return BVTKCache.get_vtkobj(self)
 
-    def reset_vtkobj(self):
+    def reset_vtkobj(self, update_id):
         '''Resets node's vtkobj'''
-        return BVTKCache.init_vtkobj(self)
+        update_necessary = BVTKCache.update_necessary(self, update_id)
+        BVTKCache.update_id(self, update_id)
+        if update_necessary:
+            BVTKCache.init_vtkobj(self)
 
     @show_custom_code
     def draw_buttons(self, context, layout):
@@ -315,7 +318,7 @@ class BVTK_Node:
 # -----------------------------------------------------------------------------
 # VTK Node Write
 # -----------------------------------------------------------------------------
-
+update_id = 0
 class BVTK_OT_NodeWrite(bpy.types.Operator):
     '''Operator to call VTK Write() for a node'''
     bl_idname = "node.bvtk_node_write"
@@ -324,12 +327,14 @@ class BVTK_OT_NodeWrite(bpy.types.Operator):
     id: bpy.props.IntProperty()
 
     def execute(self, context):
+        global update_id
+        update_id += 1
         BVTKCache.check_cache()
-        node = get_node(self.id)  # TODO: change node_id to node_path?
+        node = BVTKCache.get_node(self.id)  # TODO: change node_id to node_path?
         if node:
             def cb():
                 node.get_vtkobj().Write()
-            Update(node, cb)
+            Update(node, cb, update_id)
 
         return {'FINISHED'}
 

--- a/custom_nodes/VTKFilters.py
+++ b/custom_nodes/VTKFilters.py
@@ -172,11 +172,22 @@ class VTKAppendFilter(Node, BVTK_Node):
         for node, in_obj in self.get_input_nodes('input'):
             toadd.append(in_obj)
             if in_obj not in added:
-                vtkobj.AddInputConnection(in_obj)
+                if in_obj.IsA('vtkAlgorithmOutput'):
+                    vtkobj.AddInputConnection(in_obj)
+                else:
+                    vtkobj.AddInputData(in_obj)
 
         for obj in added:
             if obj not in toadd:
-                vtkobj.RemoveInputConnection(0, obj)
+                if in_obj.IsA('vtkAlgorithmOutput'):
+                    vtkobj.RemoveInputConnection(0, in_obj)
+                else:
+                    vtkobj.RemoveInputData(in_obj)
+
+    def get_output(self, socketname):
+        vtkobj = self.get_vtkobj()
+        if not vtkobj in [None, 0] and hasattr(vtkobj, 'GetOutput'):
+            return vtkobj.GetOutput()
 
 
 add_class(VTKAppendFilter)

--- a/update.py
+++ b/update.py
@@ -40,7 +40,7 @@ def SetInputObj(vtkobj, name, input_obj):
     exec(cmd, globals(), locals())
 
 
-def Update(node, cb, x=True):
+def Update(node, cb, update_id, x=True):
     '''Update the input functions of this node using the function queue.
     Sets color of node to reflect node run status. Finally updates this
     node and queues argument function cb() if argument x is True.
@@ -53,14 +53,14 @@ def Update(node, cb, x=True):
     execute_color = 0.85, 0.6, 0.2 # Execution color
 
     # Reset vtkobj before executing update stack
-    node.reset_vtkobj()
+    node.reset_vtkobj(update_id)
 
     vtkobj = node.get_vtkobj()
 
     # Call update for input nodes
     queue.add(SetColor, node, inputs_color)
     for input_node in node.input_nodes():
-        Update(input_node, None, False)
+        Update(input_node, None, update_id, False)
     queue.add(SetColor, node, execute_color)
 
     # Update VTK object


### PR DESCRIPTION
This PR aims to fix the issue in #55, where creating diamond-like connection pattern results in the Cache creating multiple instances of the same filter, but only applying the input to one of them. This fix introduces a new update ID that only clears the cache for each object if the update ID does not match the last update ID. I'm not sure if this conflicts with #46 

Minor fixes:
- AppendFilter did not work properly with direct data structures
- VTK Writers were not working (get_node now in BVTKCache)