### PR TITLE
Make ColorMapper node work with vectors

### DIFF
--- a/colormap.py
+++ b/colormap.py
@@ -167,6 +167,8 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
 
         # Update range
         if self.auto_range:
+            import sys
+
             # Disable triggering of automatic node update when updating range
             # values (properties with update=BVTK_Node.outdate_vtk_status).
             # TODO: Refactor to core if some other nodes need this as well.
@@ -174,9 +176,23 @@ class BVTK_Node_ColorMapper(Node, BVTK_Node):
             old_mode = str(update_mode)
             bpy.context.scene.bvtknodes_settings.update_mode = "no-automatic-updates"
 
-            value_range = d.GetRange()
-            self.max = value_range[1]
-            self.min = value_range[0]
+            num_comps = d.GetNumberOfComponents()
+            num_tups = d.GetNumberOfTuples()
+            self.min = sys.float_info.max   # These assume floating
+            self.max = sys.float_info.min   # precision but shouldn't
+            for i in range(num_tups):
+                tup = d.GetTuple(i)
+                v = 0.0
+                # Get Euclidean norm (magnitude) of the data vector.
+                # This should leave scalars unchanged
+                for j in range(num_comps):
+                    v += tup[j] ** 2
+                v = v ** 0.5
+
+                if v < self.min:
+                    self.min = v
+                if v > self.max:
+                    self.max = v
 
             # Restore Update Mode and update if needed
             bpy.context.scene.bvtknodes_settings.update_mode = old_mode

--- a/converters.py
+++ b/converters.py
@@ -1610,12 +1610,20 @@ def image_from_ramp(ramp, name, length):
 def face_unwrap(bm, vtk_obj, array_name, vrange):
     """Unwrap by cell data"""
 
-    scalars = get_vtk_array_data(vtk_obj, array_name, array_type="C")
+    array_data = get_vtk_array_data(vtk_obj, array_name, array_type="C")
+    num_comps = array_data.GetNumberOfComponents()
     minr, maxr = vrange
     uv_layer = bm.loops.layers.uv.verify()
     for face in bm.faces:
         for loop in face.loops:
-            v = (scalars.GetValue(face.index) - minr) / (maxr - minr)
+            tup = array_data.GetTuple(face.index)
+            v = 0.0
+            # Get Euclidean norm (magnitude) of the data vector.
+            # This should leave scalars unchanged
+            for i in range(num_comps):
+                v += tup[i] ** 2
+            v = v ** 0.5
+            v = (v - minr) / (maxr - minr)
             v = min(0.999, max(0.001, v))  # Force value inside range
             loop[uv_layer].uv = (v, 0.5)
     return bm, None
@@ -1624,12 +1632,20 @@ def face_unwrap(bm, vtk_obj, array_name, vrange):
 def point_unwrap(bm, vtk_obj, array_name, vrange, vimap):
     """Unwrap by point data"""
 
-    scalars = get_vtk_array_data(vtk_obj, array_name, array_type="P")
+    array_data = get_vtk_array_data(vtk_obj, array_name, array_type="P")
+    num_comps = array_data.GetNumberOfComponents()
     minr, maxr = vrange
     uv_layer = bm.loops.layers.uv.verify()
     for face in bm.faces:
         for loop in face.loops:
-            v = (scalars.GetValue(vimap[loop.vert.index]) - minr) / (maxr - minr)
+            tup = array_data.GetTuple(vimap[loop.vert.index])
+            v = 0.0
+            # Get Euclidean norm (magnitude) of the data vector.
+            # This should leave scalars unchanged
+            for i in range(num_comps):
+                v += tup[i] ** 2
+            v = v ** 0.5
+            v = (v - minr) / (maxr - minr)
             v = min(0.999, max(0.001, v))  # Force value inside range
             loop[uv_layer].uv = (v, 0.5)
     return bm, None


### PR DESCRIPTION
The ColorMapper node workflow currently only supports scalar data for coloring.  This PR changes ColorMapper and VTKToBlenderMesh to automatically calculate and use the magnitude of the incoming vectors, while leaving scalar data unaffected, which hopefully resolves issue #58 (*Color Mapper node color by vector field magnitude*).

Below is a comparison between the old color mapper and the proposed one using the cubeflow_stream_tracers example.

The old color mapper using a raw vector array U doesn't use the magnitude of the vectors:
![bvtk-master-U](https://user-images.githubusercontent.com/38167752/180806661-6d2e64bb-bc61-44e5-8f9d-81c00abe3ecf.png)

The old color mapper using an ArrayCalculator to calculate mag(U):
![bvtk-master-mag_U](https://user-images.githubusercontent.com/38167752/180802990-471dd872-d318-4211-912c-160cc0f025d8.png)

The proposed color mapper with the raw vector array U is identical to the output with ArrayCalculator:
![bvtk-fix-issue-58-U](https://user-images.githubusercontent.com/38167752/180803367-e471fb48-2deb-48de-8010-3e9a8cc1dcc5.png)



As a side note, I'm fairly new to BVtk and vtk, so please tell me if the way I implemented this is improper or could be handled more elegantly.