### PR TITLE
Update pip_install_vtk.md

### DIFF
--- a/pip_install_vtk.md
+++ b/pip_install_vtk.md
@@ -9,12 +9,12 @@ BVTKNodes.
 Run CMD.EXE as administrator and run commands
 ```
 cd C:\Program Files\Blender Foundation\Blender\3.6\python\bin
-python.exe -m ensurepip
-python.exe -m pip install vtk==9.2.6
+.\python.exe -m ensurepip
+.\python.exe -m pip install vtk==9.2.6
 ```
 or if you need to install newest (possibly unsupported) version of vtk, replace last command with
 ```
-python.exe -m pip install vtk
+.\python.exe -m pip install vtk
 ```
 
 # On Linux


### PR DESCRIPTION
Consider to add path before, or in some case CMD.exe will use system default python instead of the one required by Blender
![2023-09-18_105724](https://github.com/tkeskita/BVtkNodes/assets/82694610/5455749c-390d-42f1-9cd0-540925bdf4f7)
