### PR TITLE
Fix #114: Freeze of VTK To Blender Volume during animation when frame changes with Update All Automatically selected

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -180,6 +180,12 @@ class BVTKNodes_Settings(bpy.types.PropertyGroup):
                 "Update changes to all nodes automatically",
                 2,
             ),
+            (
+                "animation-only-updates",
+                "Animation Only Updates",
+                "Update nodes automatically only when frame changes",
+                3,
+            ),
         },
         default="update-current",
     )
@@ -315,7 +321,7 @@ def on_frame_change(scene, depsgraph):
 
     # Restore update_mode and update if needed
     bpy.context.scene.bvtknodes_settings.update_mode = update_mode
-    if update_mode == "update-all":
+    if (update_mode == "update-all") or (update_mode == "animation-only-updates"):
         cache.BVTKCache.update_all()
 
     bpy.context.scene.bvtknodes_settings.on_frame_change_is_running = False
@@ -326,6 +332,10 @@ def on_frame_change(scene, depsgraph):
 def on_depsgraph_update(scene, depsgraph):
     """Updates done after depsgraph changes"""
 
+    update_mode = bpy.context.scene.bvtknodes_settings.update_mode
+    if update_mode == "animation-only-updates":
+        return
+    
     import time
 
     # Call on_frame_change() only when it's not anymore running.

--- a/converters.py
+++ b/converters.py
@@ -1301,6 +1301,13 @@ def delete_objects_startswith(ob_name):
     for ob in objects:
         ob.select_set(True)
         l.debug("Selected object %r" % ob.name)
+        ob_data = ob.data
+        if ob_data is None:
+            continue
+        if ob_data.users > 1:
+            continue
+        if isinstance(ob_data, bpy.types.Volume):
+            bpy.data.volumes.remove(ob_data)
     bpy.ops.object.delete(confirm=False)
 
 


### PR DESCRIPTION
I added a new Update Mode named Animation Only Updates, which updates the nodes only when the frame changes but it does not update them when the dependency graph updates. This helps to avoid the freeze of the VTK To Blender Volume node.
Note the VTK To Blender Volume node still freezes with Update All Automatically selected as Update Mode. However, rendering animations with VTK To Blender Volume node is now possible by selecting Animation Only Updates as Update Mode.

I also made a few small changes to make volume object and volume data deletion more precise when updating during animation.